### PR TITLE
Remove wrapper on dispose

### DIFF
--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -64,6 +64,7 @@ THE SOFTWARE. */
       this.el_.parentNode.className = this.el_.parentNode.className
         .replace(' vjs-youtube', '')
         .replace(' vjs-youtube-mobile', '');
+      this.el_.remove();
     },
 
     createEl: function() {


### PR DESCRIPTION
Destroy the container on dipose.

When you are changing the source beetwen mp4 and youtube videos, the container of the youtube iframe remains over the html5 video tag after the source is changed