### PR TITLE
Fixes for Brightcove Player and videojs integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 npm-debug.log
 
 dist
+.idea

--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -74,6 +74,7 @@ THE SOFTWARE. */
       var div = document.createElement('div');
       div.setAttribute('id', this.options_.techId);
       div.setAttribute('style', 'width:100%;height:100%;top:0;left:0;position:absolute');
+      div.setAttribute('class', 'vjs-tech');
 
       var divWrapper = document.createElement('div');
       divWrapper.appendChild(div);
@@ -240,7 +241,6 @@ THE SOFTWARE. */
           break;
 
         case YT.PlayerState.ENDED:
-          this.trigger('loadstart');
           this.trigger('ended');
           break;
 
@@ -462,7 +462,7 @@ THE SOFTWARE. */
     },
 
     currentSrc: function() {
-      return this.source;
+      return this.source && this.source.src;
     },
 
     ended: function() {

--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -33,10 +33,6 @@ THE SOFTWARE. */
 }(this, function(videojs) {
   'use strict';
 
-  if (!videojs.getComponent) {
-    //Old version of videojs being used, which means no YouTube support
-    return;
-  }
   var Tech = videojs.getComponent('Tech');
 
   var Youtube = videojs.extend(Tech, {
@@ -365,6 +361,10 @@ THE SOFTWARE. */
 
     loop: function() {
       return this.options_.loop;
+    },
+
+    setLoop: function(val) {
+      this.options_.loop = val;
     },
 
     play: function() {

--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -355,7 +355,17 @@ THE SOFTWARE. */
       }
     },
 
-    setAutoplay: function() {},
+    autoplay: function() {
+      return this.options_.autoplay;
+    },
+
+    setAutoplay: function(val) {
+      this.options_.autoplay = val;
+    },
+
+    loop: function() {
+      return this.options_.loop;
+    },
 
     play: function() {
       if (!this.url || !this.url.videoId) {
@@ -431,6 +441,31 @@ THE SOFTWARE. */
           }
         }.bind(this), 250);
       }
+    },
+
+    seeking: function () {
+      return this.isSeeking;
+    },
+
+    seekable: function () {
+      if(!this.ytPlayer || !this.ytPlayer.getVideoLoadedFraction) {
+        return {
+          length: 0,
+          start: function() {
+            throw new Error('This TimeRanges object is empty');
+          },
+          end: function() {
+            throw new Error('This TimeRanges object is empty');
+          }
+        };
+      }
+      var end = this.ytPlayer.getDuration();
+
+      return {
+        length: this.ytPlayer.getDuration(),
+        start: function() { return 0; },
+        end: function() { return end; }
+      };
     },
 
     onSeeked: function() {
@@ -530,6 +565,7 @@ THE SOFTWARE. */
     },
 
     // TODO: Can we really do something with this on YouTUbe?
+    preload: function() {},
     load: function() {},
     reset: function() {},
 

--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -607,7 +607,7 @@ THE SOFTWARE. */
     return (e.type === 'video/youtube');
   };
 
-  var _isOnMobile = videojs.browser.IS_IPHONE || useNativeControlsOnAndroid();
+  var _isOnMobile = videojs.browser.IS_IOS || useNativeControlsOnAndroid();
 
   Youtube.parseUrl = function(url) {
     var result = {

--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -631,11 +631,34 @@ THE SOFTWARE. */
     return result;
   };
 
-  function loadApi() {
+  function apiLoaded() {
+    YT.ready(function() {
+      Youtube.isApiReady = true;
+
+      for (var i = 0; i < Youtube.apiReadyQueue.length; ++i) {
+        Youtube.apiReadyQueue[i].initYTPlayer();
+      }
+    });
+  }
+
+  function loadScript(src, callback) {
+    var loaded = false;
     var tag = document.createElement('script');
-    tag.src = 'https://www.youtube.com/iframe_api';
     var firstScriptTag = document.getElementsByTagName('script')[0];
     firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+    tag.onload = function () {
+      if (!loaded) {
+        loaded = true;
+        callback();
+      }
+    };
+    tag.onreadystatechange = function () {
+      if (!loaded && (this.readyState === 'complete' || this.readyState === 'loaded')) {
+        loaded = true;
+        callback();
+      }
+    };
+    tag.src = src;
   }
 
   function injectCss() {
@@ -669,15 +692,7 @@ THE SOFTWARE. */
 
   Youtube.apiReadyQueue = [];
 
-  window.onYouTubeIframeAPIReady = function() {
-    Youtube.isApiReady = true;
-
-    for (var i = 0; i < Youtube.apiReadyQueue.length; ++i) {
-      Youtube.apiReadyQueue[i].initYTPlayer();
-    }
-  };
-
-  loadApi();
+  loadScript('https://www.youtube.com/iframe_api', apiLoaded);
   injectCss();
 
   // Older versions of VJS5 doesn't have the registerTech function


### PR DESCRIPTION
A number of fixes were made to the YouTube tech to allow it to be used in the Brightcove Player.  Most of these fixes also fix issues which could come up using a videojs player with certain plugins.  Here's a list of everything that was changed:

* Added .idea to the `.gitignore` file to prevent WebStorm files from being added to git
* Ensure the version of videojs we're using has the `getComponent` function before loading the tech
* Added the `vjs-tech` class to the tech element div.  This is used in several plugins with `querySelector` to retrieve the tech element div and is needed when used in a Brightcove Player.
* Added video cueing when switching sources with autoplay disabled.
* Fixed `onPlayerStateChange` by setting `laststate` before triggering any events as some listeners use the state of the player (which is stored in `laststate`)
* Added the `loadstart` event to the loading state (state -1)
* Added required videojs tech functions `autoplay`, `setAutoplay`, `loop`, `seeking`, `seekable`, and `preload`
* Return the actual source url and not the source object in `currentSrc`
* Don't use native controls on Android browsers that support using HTML controls
* Fixed conflicts with other plugins (such as IMA) which load YouTube assets by changing the loading of the iframe API.  Now, we wait for the API script to be loaded, then we register a callback to the `YT.ready` function instead of setting a `window. onYouTubeIframeAPIReady` function.  The `YT.ready` callback function is run once the API is ready to instantiate players and prevents timing issues where the `onYouTubeIframeAPIReady` function could potentially be overwritten by other code.

Feel free to leave any comments or ask any questions about any of the changes / fixes.  I am going to be away on vacation for the next week, but should hopefully be able to get around to responding to them during that time.