### PR TITLE
Allow undocumented player parameters via customVars

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,21 @@ Because `controls` is already a Video.js option, to use the YouTube controls, yo
 </video>
 ```
 
+### Custom Player Options
+If you need to set any additional options on the YouTube player, you may do so with the `customVars` parameter:
+
+```html
+<video
+  id="vid1"
+  class="video-js vjs-default-skin"
+  controls
+  autoplay
+  width="640" height="264"
+  data-setup='{ "techOrder": ["youtube"], "sources": [{ "type": "video/youtube", "src": "https://www.youtube.com/watch?v=xjS6SftYQaQ"}], "youtube": { "customVars": { "wmode": "transparent" } } }'
+>
+</video>
+```
+
 ##Special Thank You
 Thanks to Steve Heffernan for the amazing Video.js and to John Hurliman for the original version of the YouTube tech
 

--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -192,9 +192,9 @@ THE SOFTWARE. */
 
       // Allow undocumented options to be passed along via customVars
       if (typeof this.options_.customVars !== 'undefined') {
-        var self = this;
-        Object.keys(this.options_.customVars).forEach(function(key) {
-          playerVars[key] = self.options_.customVars[key];
+        var customVars = this.options_.customVars;
+        Object.keys(customVars).forEach(function(key) {
+          playerVars[key] = customVars[key];
         });
       }
 

--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -190,6 +190,14 @@ THE SOFTWARE. */
         playerVars.theme = this.options_.theme;
       }
 
+      // Allow undocumented options to be passed along via customVars
+      if (typeof this.options_.customVars !== 'undefined') {
+        var self = this;
+        Object.keys(this.options_.customVars).forEach(function(key) {
+          playerVars[key] = self.options_.customVars[key];
+        });
+      }
+
       this.activeVideoId = this.url ? this.url.videoId : null;
       this.activeList = playerVars.list;
 


### PR DESCRIPTION
Right now, the only `playerVars` allowed are those officially documented in the YouTube API. However, there are a bunch of undocumented variables that people might need to set at some point. For example, `wmode` is often needed to make the YouTube iframe behave on older versions of IE.

This PR introduces `customVars` - an option, if provided, that allows undocumented `playerVars` to be set like so:

```
youtube: {
  customVars: {
    wmode: 'transparent',
  },
}
```
