### PR TITLE
Don't destroy the YouTube player on error

### DIFF
--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -61,6 +61,19 @@ THE SOFTWARE. */
     },
 
     dispose: function() {
+      if (this.ytPlayer) {
+        //Dispose of the YouTube Player
+        this.ytPlayer.stopVideo();
+        this.ytPlayer.destroy();
+      } else {
+        //YouTube API hasn't finished loading or the player is already disposed
+        var index = Youtube.apiReadyQueue.indexOf(this);
+        if (index !== -1) {
+          Youtube.apiReadyQueue.splice(index, 1);
+        }
+      }
+      this.ytPlayer = null;
+
       this.el_.parentNode.className = this.el_.parentNode.className
         .replace(' vjs-youtube', '')
         .replace(' vjs-youtube-mobile', '');
@@ -273,8 +286,6 @@ THE SOFTWARE. */
       this.trigger('error');
 
       this.ytPlayer.stopVideo();
-      this.ytPlayer.destroy();
-      this.ytPlayer = null;
     },
 
     error: function() {

--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -78,6 +78,9 @@ THE SOFTWARE. */
         .replace(' vjs-youtube', '')
         .replace(' vjs-youtube-mobile', '');
       this.el_.remove();
+
+      //Needs to be called after the YouTube player is destroyed, otherwise there will be a null reference exception
+      Tech.prototype.dispose.call(this);
     },
 
     createEl: function() {


### PR DESCRIPTION
Features were added to videojs-youtube which allows videos to be loaded once the player is instantiated, however the player is destroyed whenever a player error occurs.  This means that calling `player.src()` with some new video url will no longer work when an error has occurred on the current video.  This PR removes the destruction of the player when an error occurs, and also destroys it properly whenever `dispose()` is called on the tech.