### PR TITLE
Associate error #150 with #101 

### DIFF
--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -284,10 +284,10 @@ THE SOFTWARE. */
 
         case 2:
         case 100:
-        case 150:
           return { code: 'Unable to find the video' };
 
         case 101:
+        case 150:
           return { code: 'Playback on other Websites has been disabled by the video owner.' };
       }
 


### PR DESCRIPTION
Error 150 should actually be associated with embed errors (101) rather than not found errors (2 and 100) per https://developers.google.com/youtube/js_api_reference#onError.