### PR TITLE
fix: support muted attribute

### DIFF
--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -230,6 +230,10 @@ THE SOFTWARE. */
     },
 
     onPlayerReady: function() {
+      if (this.options_.muted) {
+        this.ytPlayer.mute();
+      }
+
       this.playerReady_ = true;
       this.triggerReady();
 


### PR DESCRIPTION
The earliest time we can call a player method is the onready handler.
Youtube doesn't support a muted attribute, so, we just call
ytPlayer.mute() at the earlier opportinity when the attribute is set.

Fixes #385.