### PR TITLE
feat: add support for start and end times.

### DIFF
--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -240,7 +240,7 @@ THE SOFTWARE. */
       if (this.playOnReady) {
         this.play();
       } else if (this.cueOnReady) {
-        this.ytPlayer.cueVideoById(this.url.videoId);
+        this.cueVideoById_(this.url.videoId);
         this.activeVideoId = this.url.videoId;
       }
     },
@@ -320,6 +320,32 @@ THE SOFTWARE. */
       return { code: 'YouTube unknown error (' + this.errorNumber + ')' };
     },
 
+    loadVideoById_: function(id) {
+      var options = {
+        videoId: id
+      };
+      if (this.options_.start) {
+        options.startSeconds = this.options_.start;
+      }
+      if (this.options_.end) {
+        options.endEnd = this.options_.end;
+      }
+      this.ytPlayer.loadVideoById(options);
+    },
+
+    cueVideoById_: function(id) {
+      var options = {
+        videoId: id
+      };
+      if (this.options_.start) {
+        options.startSeconds = this.options_.start;
+      }
+      if (this.options_.end) {
+        options.endEnd = this.options_.end;
+      }
+      this.ytPlayer.cueVideoById(options);
+    },
+
     src: function(src) {
       if (src) {
         this.setSrc({ src: src });
@@ -370,7 +396,7 @@ THE SOFTWARE. */
         }
       } else if (this.activeVideoId !== this.url.videoId) {
         if (this.isReady_) {
-          this.ytPlayer.cueVideoById(this.url.videoId);
+          this.cueVideoById_(this.url.videoId);
           this.activeVideoId = this.url.videoId;
         } else {
           this.cueOnReady = true;
@@ -414,7 +440,7 @@ THE SOFTWARE. */
         if (this.activeVideoId === this.url.videoId) {
           this.ytPlayer.playVideo();
         } else {
-          this.ytPlayer.loadVideoById(this.url.videoId);
+          this.loadVideoById_(this.url.videoId);
           this.activeVideoId = this.url.videoId;
         }
       } else {


### PR DESCRIPTION
Because of how we parse the url of the youtube video, start and end
times were getting stripped. However, passing them to the as playerVars
wasn't working for some reason. So, instead, use startSeconds and
endSeconds in load and cue video by id methods.

Fixes #388.