### PR TITLE
fix: prevent exception when quick dispose and YT not ready yet

### DIFF
--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -64,8 +64,12 @@ THE SOFTWARE. */
     dispose: function() {
       if (this.ytPlayer) {
         //Dispose of the YouTube Player
-        this.ytPlayer.stopVideo();
-        this.ytPlayer.destroy();
+        if (this.ytPlayer.stopVideo) {
+          this.ytPlayer.stopVideo();
+        }
+        if (this.ytPlayer.destroy) {
+          this.ytPlayer.destroy();
+        }
       } else {
         //YouTube API hasn't finished loading or the player is already disposed
         var index = Youtube.apiReadyQueue.indexOf(this);

--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -47,16 +47,18 @@ THE SOFTWARE. */
       // Set the vjs-youtube class to the player
       // Parent is not set yet so we have to wait a tick
       setTimeout(function() {
-        this.el_.parentNode.className += ' vjs-youtube';
+        if (this.el_) {
+          this.el_.parentNode.className += ' vjs-youtube';
 
-        if (_isOnMobile) {
-          this.el_.parentNode.className += ' vjs-youtube-mobile';
-        }
+          if (_isOnMobile) {
+            this.el_.parentNode.className += ' vjs-youtube-mobile';
+          }
 
-        if (Youtube.isApiReady) {
-          this.initYTPlayer();
-        } else {
-          Youtube.apiReadyQueue.push(this);
+          if (Youtube.isApiReady) {
+            this.initYTPlayer();
+          } else {
+            Youtube.apiReadyQueue.push(this);
+          }
         }
       }.bind(this));
     },


### PR DESCRIPTION
there is an exception is you dispose the player while the YT api is not loaded yet. this fix prevent crashs in such edge cases.