### PR TITLE
Video.js 5/6 cross-compatibility

### DIFF
--- a/examples/global-parameters.html
+++ b/examples/global-parameters.html
@@ -12,8 +12,8 @@
   >
   </video>
 
-  <script src="../node_modules/video.js/dist/video.min.js"></script>
-  <script src="../dist/Youtube.min.js"></script>
+  <script src="../node_modules/video.js/dist/video.js"></script>
+  <script src="../dist/Youtube.js"></script>
   <script>
   // You can use any YouTube player parameters
   // https://developers.google.com/youtube/player_parameters?playerVersion=HTML5#Parameters

--- a/examples/simple.html
+++ b/examples/simple.html
@@ -14,7 +14,7 @@
   >
   </video>
 
-  <script src="../node_modules/video.js/dist/video.min.js"></script>
-  <script src="../dist/Youtube.min.js"></script>
+  <script src="../node_modules/video.js/dist/video.js"></script>
+  <script src="../dist/Youtube.js"></script>
 </body>
 </html>

--- a/examples/youtube-controls.html
+++ b/examples/youtube-controls.html
@@ -12,7 +12,7 @@
   >
   </video>
 
-  <script src="../node_modules/video.js/dist/video.min.js"></script>
-  <script src="../dist/Youtube.min.js"></script>
+  <script src="../node_modules/video.js/dist/video.js"></script>
+  <script src="../dist/Youtube.js"></script>
 </body>
 </html>

--- a/examples/youtube-javascript.html
+++ b/examples/youtube-javascript.html
@@ -13,8 +13,8 @@
   >
   </video>
 
-  <script src="../node_modules/video.js/dist/video.min.js"></script>
-  <script src="../dist/Youtube.min.js"></script>
+  <script src="../node_modules/video.js/dist/video.js"></script>
+  <script src="../dist/Youtube.js"></script>
   <script>
   // An example of playing with the Video.js javascript API
   // You can look at the doc there: http://docs.videojs.com/docs/guides/api.html

--- a/examples/youtube-list.html
+++ b/examples/youtube-list.html
@@ -13,7 +13,7 @@
   >
   </video>
 
-  <script src="../node_modules/video.js/dist/video.min.js"></script>
-  <script src="../dist/Youtube.min.js"></script>
+  <script src="../node_modules/video.js/dist/video.js"></script>
+  <script src="../dist/Youtube.js"></script>
 </body>
 </html>

--- a/examples/youtube-playlist.html
+++ b/examples/youtube-playlist.html
@@ -13,7 +13,7 @@
   >
   </video>
 
-  <script src="../node_modules/video.js/dist/video.min.js"></script>
-  <script src="../dist/Youtube.min.js"></script>
+  <script src="../node_modules/video.js/dist/video.js"></script>
+  <script src="../dist/Youtube.js"></script>
 </body>
 </html>

--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -34,8 +34,7 @@ THE SOFTWARE. */
   'use strict';
 
   var _isOnMobile = videojs.browser.IS_IOS || videojs.browser.IS_ANDROID;
-
-  var Tech = videojs.getComponent('Tech');
+  var Tech = videojs.getTech('Tech');
 
   var Youtube = videojs.extend(Tech, {
 
@@ -327,9 +326,9 @@ THE SOFTWARE. */
 
         case 101:
         case 150:
-          return { 
-            code: code, 
-            message: 'Playback on other Websites has been disabled by the video owner.' 
+          return {
+            code: code,
+            message: 'Playback on other Websites has been disabled by the video owner.'
           };
       }
 


### PR DESCRIPTION
There are errors in the console for this plugin, but it appears they are not a consequence of Video.js 6 - they appear with 5, too.