### PR TITLE
adjust full screen support

### DIFF
--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -619,7 +619,9 @@ THE SOFTWARE. */
     reset: function() {},
 
     supportsFullScreen: function() {
-      return true;
+      return document.webkitFullscreenEnabled ||
+             document.mozFullScreenEnabled ||
+             document.msFullscreenEnabled;
     },
 
     // Tries to get the highest resolution thumbnail available for the video

--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -619,7 +619,8 @@ THE SOFTWARE. */
     reset: function() {},
 
     supportsFullScreen: function() {
-      return document.webkitFullscreenEnabled ||
+      return document.fullscreenEnabled ||
+             document.webkitFullscreenEnabled ||
              document.mozFullScreenEnabled ||
              document.msFullscreenEnabled;
     },


### PR DESCRIPTION
The current implementation of `supportsFullScreen` is just returning `true` (https://github.com/videojs/videojs-youtube/blob/master/src/Youtube.js#L621-L623), which seems to be not functioning well in iOS.  In order to fall back to full window mode in videoJS, I've made some changes to check three vendor `fullscreen` methods.

This would be one possible solution to https://github.com/videojs/videojs-youtube/issues/431.