### PR TITLE
Do not support fullscreen on iOS

### DIFF
--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -619,7 +619,9 @@ THE SOFTWARE. */
     reset: function() {},
 
     supportsFullScreen: function() {
-      return true;
+      return document.webkitFullscreenEnabled ||
+        document.mozFullScreenEnabled ||
+        document.msFullscreenEnabled;
     },
 
     // Tries to get the highest resolution thumbnail available for the video


### PR DESCRIPTION
(disregard, duplicate of https://github.com/videojs/videojs-youtube/pull/458)
