### PR TITLE
adds an if statement to prevent breaking in jest

### DIFF
--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -740,7 +740,11 @@ THE SOFTWARE. */
     var loaded = false;
     var tag = document.createElement('script');
     var firstScriptTag = document.getElementsByTagName('script')[0];
-    if (!firstScriptTag) return // when loaded in jest without jsdom setup it doesn't get any element. In jest it doesn't really make sense to do anything, because no one is watching youtube in jest
+    if (!firstScriptTag) {
+      // when loaded in jest without jsdom setup it doesn't get any element.
+      // In jest it doesn't really make sense to do anything, because no one is watching youtube in jest
+      return;
+    }
     firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
     tag.onload = function () {
       if (!loaded) {

--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -740,6 +740,7 @@ THE SOFTWARE. */
     var loaded = false;
     var tag = document.createElement('script');
     var firstScriptTag = document.getElementsByTagName('script')[0];
+    if (!firstScriptTag) return // when loaded in jest without jsdom setup it doesn't get any element. In jest it doesn't really make sense to do anything, because no one is watching youtube in jest
     firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
     tag.onload = function () {
       if (!loaded) {


### PR DESCRIPTION
without a proper jsdom this fails in jest:

![image](https://user-images.githubusercontent.com/1305378/48168128-689ccb00-e2ee-11e8-9267-066466a8daea.png)

with this safeguard it run fine in jest.

IMHO it's nice to support testability like this.
Setting up a jsdom every time is a needless pain.